### PR TITLE
Simplify resource specification.

### DIFF
--- a/charts/misolib/Chart.yaml
+++ b/charts/misolib/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.0.0
 description: A library chart for deployment to Miso cluster.
 name: misolib
 type: library
-version: 0.1.10
+version: 0.1.11

--- a/charts/misolib/README.md
+++ b/charts/misolib/README.md
@@ -64,6 +64,11 @@ The following tables lists the configurable parameters of the library and their 
 | `volumeMounts` | List of volume mounts to use in statefulsets | `[]` |
 | `volumeClaimTemplates` | List of volume claim templates to use in statefulsets | `[]` |
 | `services` | Additional services list. If this is not provided then following `service` value will take precedence. | `[]` |
+| `services[INDEX].name` | Name of the service. | `Null` |
+| `services[INDEX].ports` | List of ports for the first item(service) in the list | `[]` |
+| `services[INDEX].ports[INDEX].name` | Name of the port | `Null` |
+| `services[INDEX].ports[INDEX].port` | Port number | `Null` |
+| `services[INDEX].ports[INDEX].targetPort` | Target port number of the service's port | `Null` |
 | `service.annotations` | Annotations to add to service. | `{}` |
 | `service.type` | Service resource type: NodePort, ClusterIp | `NodePort` |
 | `service.port` | Port of the service | `80` |

--- a/charts/misolib/templates/_deployment.tpl
+++ b/charts/misolib/templates/_deployment.tpl
@@ -78,16 +78,7 @@ spec:
               port: {{ .Values.readinessProbe.port }}
           {{- end }}
           resources:
-            {{- if and .Values.resources.production (eq .Values.stage "production") }}
-            {{- toYaml .Values.resources.production | nindent 12 }}
-            {{- else if and .Values.resources.staging (eq .Values.stage "staging") }}
-            {{- toYaml .Values.resources.staging | nindent 12 }}
-            {{- else }}
-            limits:
-              {{- toYaml .Values.resources.limits | nindent 14 }}
-            requests:
-              {{- toYaml .Values.resources.requests | nindent 14 }}
-            {{- end}}
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/misolib/templates/_statefulset.tpl
+++ b/charts/misolib/templates/_statefulset.tpl
@@ -85,16 +85,7 @@ spec:
               port: {{ .Values.readinessProbe.port }}
           {{- end }}
           resources:
-            {{- if and .Values.resources.production (eq .Values.stage "production") }}
-            {{- toYaml .Values.resources.production | nindent 12 }}
-            {{- else if and .Values.resources.staging (eq .Values.stage "staging") }}
-            {{- toYaml .Values.resources.staging | nindent 12 }}
-            {{- else }}
-            limits:
-              {{- toYaml .Values.resources.limits | nindent 14 }}
-            requests:
-              {{- toYaml .Values.resources.requests | nindent 14 }}
-            {{- end}}
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/examples/deployment/.helm/values.yaml
+++ b/examples/deployment/.helm/values.yaml
@@ -4,10 +4,9 @@ image:
   repository: nginx
   tag: latest
 resources:
-  production:
-    limits:
-      cpu: "0.7"
-      memory: 900Mi
-    requests:
-      cpu: "0.5"
-      memory: 700Mi
+  limits:
+    cpu: "0.7"
+    memory: 900Mi
+  requests:
+    cpu: "0.5"
+    memory: 700Mi

--- a/examples/hpa/.helm/Chart.yaml
+++ b/examples/hpa/.helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: example-deployment
+name: example-hpa
 description: An example application chart that uses librarychart
 type: application
 version: 0.1.0

--- a/examples/hpa/.helm/templates/hpa.yaml
+++ b/examples/hpa/.helm/templates/hpa.yaml
@@ -1,0 +1,1 @@
+{{ include "misolib.hpa" .}}

--- a/examples/hpa/.helm/values.yaml
+++ b/examples/hpa/.helm/values.yaml
@@ -1,0 +1,3 @@
+autoscaling:
+  targetCPUUtilizationPercentage: 49
+  targetMemoryUtilizationPercentage: null

--- a/examples/statefulset/.helm/Chart.yaml
+++ b/examples/statefulset/.helm/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 appVersion: "1.0.0"
 dependencies:
   - name: misolib
-    version: 0.1.8
+    version: 0.1.11
     repository: https://raw.githubusercontent.com/getmiso/helm-charts/gh-pages
     import-values:
       - defaults

--- a/examples/statefulset/.helm/values.yaml
+++ b/examples/statefulset/.helm/values.yaml
@@ -12,10 +12,9 @@ volumeClaimTemplates:
     accessModes: ["ReadWriteOnce"]
     requestedStorage: 15Gi
 resources:
-  production:
-    limits:
-      cpu: "0.7"
-      memory: 900Mi
-    requests:
-      cpu: "0.5"
-      memory: 700Mi
+  limits:
+    cpu: "0.7"
+    memory: 900Mi
+  requests:
+    cpu: "0.5"
+    memory: 700Mi


### PR DESCRIPTION
#### This PR will: 
- remove stage-specific resource allication logic from misolib/deployment,statefulset
- update examples
- add missing `services` values reference into README
- add hpa example that overrides default values with `null` 

Fixes https://linear.app/miso/issue/PLA-19/set-same-cpumemory-resource-to-both-staging-and-production-deloyments
